### PR TITLE
Skip single step

### DIFF
--- a/lib/porch/context.rb
+++ b/lib/porch/context.rb
@@ -44,6 +44,12 @@ module Porch
       super
     end
 
+    def next(&block)
+      result = Guard.new(self).against(&block)
+      raise Porch::ContextStoppedError.new(self) if result.failure?
+      result
+    end
+
     def skip_remaining?
       !!@skip_remaining
     end

--- a/spec/features/skipping_current_action_spec.rb
+++ b/spec/features/skipping_current_action_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe "skipping current action" do
+  class SkippingCurrentStepExample
+    include Porch::Organizer
+
+    def run
+      with do |chain|
+        chain.add :first_step
+        chain.add :second_step
+      end
+    end
+
+    private
+
+    def first_step(context)
+      context.next { required(:blah).filled }
+      context[:got_here] = true
+    end
+
+    def second_step(context)
+    end
+  end
+
+  subject { SkippingCurrentStepExample.new }
+
+  it "skips the remaining logic in the current step" do
+    result = subject.run
+
+    expect(result[:got_here]).to be_nil
+  end
+end

--- a/spec/porch/context_spec.rb
+++ b/spec/porch/context_spec.rb
@@ -118,6 +118,17 @@ RSpec.describe Porch::Context do
     end
   end
 
+  describe "#next" do
+    subject { described_class.new({email: ""}) }
+
+    context "with invalid arguments" do
+      it "skips the current action" do
+        expect { subject.next { required(:email).filled } }.to \
+          raise_error Porch::ContextStoppedError
+      end
+    end
+  end
+
   describe "#stop_processing?" do
     subject { described_class.new({}, true) }
 


### PR DESCRIPTION
Allows a step to be skipped on the `Context` with a `#next` method.

If the block does not pass, the current step will be skipped and move onto the next step.

```
class SomeStep
  def call(context)
    context.next { required(:email).filled }
  end
end
```