### PR TITLE
Rescue from

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,28 +74,6 @@ end
 
 ### Defining steps or actions
 
-You can define steps as classes and include some nice helper methods. (COMING SOON)
-
-```
-# app/services/steps/create_user.rb
-
-require "porch"
-
-class CreateUser
-  include Porch::Step
-
-  params do
-    required(:email).filled(type?: :str, format?: RegEx.email_address)
-    required(:password).filled(type?: :str, min_size?: 8)
-  end
-
-  def call(context)
-    context.user = User.create email: context.email, password: context.password
-    context.fail! context.user.errors unless context.user.valid?
-  end
-end
-```
-
 You can define steps as PORO classes that respond to a call method.
 
 ```

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ end
 
 Errors may be raised within your steps at any point and you may want to handle those errors gracefully.
 
-You can use the `rescue_from` error handlers to handle various errors gracefully.
+You can use the `rescue_from` error handlers to handle various errors gracefully. The error handler will be called for the type of error or a descendent of the type of error.
 
 You can `rescue_from` various errors with a method.
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,40 @@ if result.failure?
 end
 ```
 
+### Handling/rescuing from errors
+
+Errors may be raised within your steps at any point and you may want to handle those errors gracefully.
+
+You can use the `rescue_from` error handlers to handle various errors gracefully.
+
+You can `rescue_from` various errors with a method.
+
+```
+class RegistersUser
+  include Porch::Organizer
+
+  rescue_from [Net::SMTPAuthenticationError, Net::SMTPServerBusy], with: :smtp_error
+
+  private
+
+  def smtp_error(exception)
+    logger.error exception
+  end
+end
+```
+
+You can `rescue_from` various errors with a block.
+
+```
+class RegistersUser
+  include Porch::Organizer
+
+  rescue_from Net::SMTPAuthenticationError do |exception|
+    logger.error exception
+  end
+end
+```
+
 ### Skipping steps
 
 At any step, you can skip the remaining actions in the organizer. This stops the running of the remaining actions but the `Porch::Context` will still return a successful `Porch::Context`.

--- a/lib/porch.rb
+++ b/lib/porch.rb
@@ -5,6 +5,7 @@ require "porch/executable_step_decorator"
 require "porch/human_error"
 require "porch/guard_rail"
 require "porch/organizer"
+require "porch/rescuable"
 require "porch/step_chain"
 require "porch/version"
 

--- a/lib/porch/organizer.rb
+++ b/lib/porch/organizer.rb
@@ -1,3 +1,5 @@
+require_relative "rescuable"
+
 module Porch
   module Organizer
     attr_reader :context
@@ -9,6 +11,12 @@ module Porch
       yield chain if block_given?
 
       chain.execute context
+    end
+
+    def self.included(base)
+      base.class_eval do
+        include Rescuable
+      end
     end
   end
 end

--- a/lib/porch/organizer.rb
+++ b/lib/porch/organizer.rb
@@ -7,10 +7,12 @@ module Porch
     def with(parameters={})
       @context = Context.new parameters
 
-      chain = StepChain.new(self)
-      yield chain if block_given?
+      handle_exceptions do
+        chain = StepChain.new(self)
+        yield chain if block_given?
 
-      chain.execute context
+        chain.execute context
+      end
     end
 
     def self.included(base)

--- a/lib/porch/rescuable.rb
+++ b/lib/porch/rescuable.rb
@@ -21,7 +21,13 @@ module Porch
     def rescue_with_handler(exception)
       handler = handler_for_rescue(exception)
       unless handler.nil?
-        self.instance_exec exception, &handler
+        case handler
+        when Symbol
+          self.method(handler).call exception
+        when Proc
+          self.instance_exec exception, &handler
+        end
+
         exception
       end
     end

--- a/lib/porch/rescuable.rb
+++ b/lib/porch/rescuable.rb
@@ -1,9 +1,5 @@
 module Porch
   module Rescuable
-    def self.included(base)
-      base.extend ClassMethods
-    end
-
     def handle_exceptions
       yield if block_given?
     rescue Exception => e
@@ -47,6 +43,10 @@ module Porch
       def rescue_handlers
         @rescue_handlers ||= []
       end
+    end
+
+    def self.included(base)
+      base.extend ClassMethods
     end
   end
 end

--- a/lib/porch/rescuable.rb
+++ b/lib/porch/rescuable.rb
@@ -4,8 +4,36 @@ module Porch
       base.extend ClassMethods
     end
 
+    def handler_for_rescue(exception)
+      _, handler = self.class.rescue_handlers.detect do |exception_class, _|
+        exception_class === exception
+      end
+
+      handler
+    end
+
+    def rescue_with_handler(exception)
+      handler = handler_for_rescue(exception)
+      unless handler.nil?
+        self.instance_exec exception, &handler
+        exception
+      end
+    end
+
     module ClassMethods
       def rescue_from(*klasses, with: nil, &block)
+        handler = block_given? ? block : with
+        raise ArgumentError, \
+          "Requires a handler. Use the with keyword argument or supply a block." \
+          if handler.nil?
+
+        klasses.each do |klass|
+          rescue_handlers << [klass, handler]
+        end
+      end
+
+      def rescue_handlers
+        @rescue_handlers ||= []
       end
     end
   end

--- a/lib/porch/rescuable.rb
+++ b/lib/porch/rescuable.rb
@@ -4,6 +4,12 @@ module Porch
       base.extend ClassMethods
     end
 
+    def handle_exceptions
+      yield if block_given?
+    rescue Exception => e
+      rescue_with_handler(e) || raise(e)
+    end
+
     def handler_for_rescue(exception)
       _, handler = self.class.rescue_handlers.detect do |exception_class, _|
         exception_class === exception

--- a/lib/porch/rescuable.rb
+++ b/lib/porch/rescuable.rb
@@ -1,0 +1,12 @@
+module Porch
+  module Rescuable
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      def rescue_from(*klasses, with: nil, &block)
+      end
+    end
+  end
+end

--- a/spec/porch/organizer_spec.rb
+++ b/spec/porch/organizer_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Porch::Organizer do
     expect(subject).to respond_to(:with).with(1).argument
   end
 
+  it "adds a `rescue_from` class method" do
+    expect(subject.class).to respond_to(:rescue_from)
+  end
+
   it "adds access to the context" do
     expect(subject).to respond_to(:context)
   end
@@ -32,6 +36,37 @@ RSpec.describe Porch::Organizer do
         receive(:execute).with(Porch::Context)
 
       subject.with
+    end
+  end
+
+  xdescribe ".rescue_from" do
+    class DoSomething
+      include Porch::Organizer
+
+      attr_reader :result
+
+      rescue_from RuntimeError do |exception|
+        @result = exception
+      end
+
+      def process
+        with do |chain|
+          chain.add :do_something_funky
+        end
+      end
+
+      private
+
+      def do_something_funky(context)
+        raise RuntimeError
+      end
+    end
+
+    subject { DoSomething.new }
+
+    it "handles errors that come from any of the steps", focus: true do
+      expect { subject.process }.to_not raise_error
+      # TODO: Expect the result
     end
   end
 end

--- a/spec/porch/organizer_spec.rb
+++ b/spec/porch/organizer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Porch::Organizer do
     end
   end
 
-  xdescribe ".rescue_from" do
+  describe ".rescue_from" do
     class DoSomething
       include Porch::Organizer
 
@@ -64,9 +64,9 @@ RSpec.describe Porch::Organizer do
 
     subject { DoSomething.new }
 
-    it "handles errors that come from any of the steps", focus: true do
+    it "handles errors that come from any of the steps" do
       expect { subject.process }.to_not raise_error
-      # TODO: Expect the result
+      expect(subject.result).to be_kind_of RuntimeError
     end
   end
 end

--- a/spec/porch/rescuable_spec.rb
+++ b/spec/porch/rescuable_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe Porch::Rescuable do
   class WeirdError < RuntimeError; end
   class MethodError < RuntimeError; end
+  class ParentError < NotImplementedError; end
 
   class ReallyScrewedUpClass
     include Porch::Rescuable
@@ -8,7 +9,7 @@ RSpec.describe Porch::Rescuable do
     attr_reader :result
 
     rescue_from MethodError, with: :method_handler
-    rescue_from WeirdError do |exception|
+    rescue_from WeirdError, NotImplementedError do |exception|
       @result = exception
     end
 
@@ -61,5 +62,11 @@ RSpec.describe Porch::Rescuable do
 
   it "is not called when the exception does not match" do
     expect { subject.safely_raise_error RuntimeError }.to raise_error RuntimeError
+  end
+
+  it "is called when the error is a descendant of the raised exception" do
+    subject.safely_raise_error ParentError
+
+    expect(subject.result).to be_kind_of NotImplementedError
   end
 end

--- a/spec/porch/rescuable_spec.rb
+++ b/spec/porch/rescuable_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe Porch::Rescuable do
     end
 
     def safely_raise_error(error)
-      raise_error error
-    rescue Exception => e
-      rescue_with_handler(e) || raise(e)
+      handle_exceptions do
+        raise_error error
+      end
     end
 
     def raise_error(error)
@@ -35,13 +35,15 @@ RSpec.describe Porch::Rescuable do
     expect { subject.class.rescue_from RuntimeError }.to raise_error ArgumentError
   end
 
-  it "is called when the exception class matches" do
-    subject.safely_raise_error WeirdError
+  context "with a block" do
+    it "is called when the exception class matches" do
+      subject.safely_raise_error WeirdError
 
-    expect(subject.result).to be_kind_of WeirdError
-  end
+      expect(subject.result).to be_kind_of WeirdError
+    end
 
-  it "is not called when the exception does not match" do
-    expect { subject.safely_raise_error RuntimeError }.to raise_error RuntimeError
+    it "is not called when the exception does not match" do
+      expect { subject.safely_raise_error RuntimeError }.to raise_error RuntimeError
+    end
   end
 end

--- a/spec/porch/rescuable_spec.rb
+++ b/spec/porch/rescuable_spec.rb
@@ -1,8 +1,47 @@
 RSpec.describe Porch::Rescuable do
-  let(:dummy_class) { Class.new { include Porch::Rescuable } }
-  subject { dummy_class.new }
+  class WeirdError < RuntimeError; end
+
+  class ReallyScrewedUpClass
+    include Porch::Rescuable
+
+    attr_reader :result
+
+    rescue_from WeirdError do |exception|
+      @result = exception
+    end
+
+    def safely_raise_error(error)
+      raise_error error
+    rescue Exception => e
+      rescue_with_handler(e) || raise(e)
+    end
+
+    def raise_error(error)
+      raise error
+    end
+  end
+
+  subject { ReallyScrewedUpClass.new }
 
   it "adds a `rescue_from` class method" do
     expect(subject.class).to respond_to(:rescue_from)
+  end
+
+  it "handles the error" do
+    expect { subject.safely_raise_error WeirdError }.to_not raise_error
+  end
+
+  it "raises an exception if a method name or proc are not provided" do
+    expect { subject.class.rescue_from RuntimeError }.to raise_error ArgumentError
+  end
+
+  it "is called when the exception class matches" do
+    subject.safely_raise_error WeirdError
+
+    expect(subject.result).to be_kind_of WeirdError
+  end
+
+  it "is not called when the exception does not match" do
+    expect { subject.safely_raise_error RuntimeError }.to raise_error RuntimeError
   end
 end

--- a/spec/porch/rescuable_spec.rb
+++ b/spec/porch/rescuable_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe Porch::Rescuable do
+  let(:dummy_class) { Class.new { include Porch::Rescuable } }
+  subject { dummy_class.new }
+
+  it "adds a `rescue_from` class method" do
+    expect(subject.class).to respond_to(:rescue_from)
+  end
+end


### PR DESCRIPTION
Adds the ability to handle errors gracefully from within the `Porch::Organizer`.

A method or a block can be defined as a handler for a given type or descendent of an error.

```
class ReallyScrewedUpClass
  include Porch::Organizer

  rescue_from MethodError, with: :method_handler
  rescue_from WeirdError, NotImplementedError do |exception|
      logger.error exception
  end

  private

  def method_handler(exception)
    logger.error exception
  end
end
```